### PR TITLE
Change statemanager signature, use encoded data

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ The main state in faasflow is the **`execution-position` (next-phase)** and the 
 Apart from that faasflow allow user to define state with `StateManager` interface.   
 ```go
  type StateManager interface {
-	Set(key string, value interface{}) error
-	Get(key string) (interface{}, error)
+	Set(key string, value string) error
+	Get(key string) (string, error)
 	Del(key string) error
  }
 ```
@@ -273,8 +273,8 @@ Apart from that faasflow allow user to define state with `StateManager` interfac
 State manager can be implemented and set by user with request context in faasflow `Define()`:
 ```go
 func Define(flow *faasflow.Workflow, context *faasflow.Context) (err error) {
-     // initialize my custom StateManager as myStateManager
-     context.SetStateManager(myStateManager)
+     // initialize my custom StateManager as minioStateManager
+     context.SetStateManager(minioStateManager)
 }
 ```
     

--- a/example/upload-pipeline-async/handler.go
+++ b/example/upload-pipeline-async/handler.go
@@ -120,7 +120,8 @@ func Define(flow *faasflow.Workflow, context *faasflow.Context) (err error) {
 			// validate face
 			err := validateFace(data)
 			if err != nil {
-				return nil, err
+				file, _ := context.GetString("fileName")
+				return nil, fmt.Errorf("File %s, %v", file, err)
 			}
 			// Get data from context
 			rawdata, err := context.GetBytes("rawImage")

--- a/template/faasflow/request.go
+++ b/template/faasflow/request.go
@@ -13,7 +13,7 @@ type Request struct {
 	ExecutionState string `json: "state"` // Execution State
 	Data           []byte `json: "data"`  // Partial execution data
 
-	ContextState map[string]interface{} `json: "state"` // Context State for default StateManager
+	ContextState map[string]string `json: "state"` // Context State for default StateManager
 }
 
 const (
@@ -25,7 +25,7 @@ func buildRequest(id string,
 	state string,
 	query string,
 	data []byte,
-	contextstate map[string]interface{}) *Request {
+	contextstate map[string]string) *Request {
 
 	request := &Request{
 		Sign:           SIGN,
@@ -66,7 +66,7 @@ func (req *Request) getExecutionState() string {
 	return req.ExecutionState
 }
 
-func (req *Request) getContextState() map[string]interface{} {
+func (req *Request) getContextState() map[string]string {
 	return req.ContextState
 }
 

--- a/template/faasflow/statemanager.go
+++ b/template/faasflow/statemanager.go
@@ -6,34 +6,34 @@ import (
 
 // json to encode
 type requestEmbedStateManager struct {
-	state map[string]interface{}
+	state map[string]string
 }
 
 // CreateStateManager creates a new requestEmbedStateManager
 func createStateManager() *requestEmbedStateManager {
 	rstate := &requestEmbedStateManager{}
-	rstate.state = make(map[string]interface{})
+	rstate.state = make(map[string]string)
 	return rstate
 }
 
 // RetriveStateManager creates a state manager from a map
-func retriveStateManager(state map[string]interface{}) *requestEmbedStateManager {
+func retriveStateManager(state map[string]string) *requestEmbedStateManager {
 	rstate := &requestEmbedStateManager{}
 	rstate.state = state
 	return rstate
 }
 
 // Set sets a value (implement StateManager)
-func (rstate *requestEmbedStateManager) Set(key string, value interface{}) error {
+func (rstate *requestEmbedStateManager) Set(key string, value string) error {
 	rstate.state[key] = value
 	return nil
 }
 
 // Get gets a value (implement StateManager)
-func (rstate *requestEmbedStateManager) Get(key string) (interface{}, error) {
+func (rstate *requestEmbedStateManager) Get(key string) (string, error) {
 	value, ok := rstate.state[key]
 	if !ok {
-		return nil, fmt.Errorf("No field name %s", key)
+		return "", fmt.Errorf("No field name %s", key)
 	}
 	return value, nil
 }


### PR DESCRIPTION
This PR Changes the StateManager interface as:
```go
// StateManager for State Manager
type StateManager interface {
        // Set store a value for key, in failure returns error
        Set(key string, value string) error
        // Get retrives a value by key, if failure returns error
        Get(key string) (string, error)
        // Del delets a value by a key
        Del(key string) error
}
```
Handling flat `string` is much easier than handling `interface{}`. Here `string` in an encoded data string that abstracts the underline data type, making it easier to be handled by the `StateManager` implementor. The encoding and decoding is done by the `context` manager in faasflow.

Signed-off-by: s8sg <swarvanusg@gmail.com>