### PR TITLE
This commit implements intermediate_storage  

### DIFF
--- a/context.go
+++ b/context.go
@@ -18,6 +18,8 @@ type Context struct {
 
 // StateManager for State Manager
 type StateManager interface {
+	// Initialize the StateManager with flow name and request ID
+	Init(flowName string, requestId string) error
 	// Set store a value for key, in failure returns error
 	Set(key string, value string) error
 	// Get retrives a value by key, if failure returns error
@@ -46,9 +48,14 @@ func CreateContext(id string, phase int, name string) *Context {
 	return context
 }
 
-// SetStateManager sets the state manager
-func (context *Context) SetStateManager(state StateManager) {
+// SetStateManager sets and overwrite the state manager
+func (context *Context) SetStateManager(state StateManager) error {
 	context.stateManager = state
+	err := context.stateManager.Init(context.Name, context.requestId)
+	if err != nil {
+		return fmt.Errorf("Failed to initialize StateManager, error %v", err)
+	}
+	return nil
 }
 
 // GetRequestId returns the request id

--- a/context.go
+++ b/context.go
@@ -107,19 +107,20 @@ func (context *Context) GetInt(key string) (int, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value int    `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	intData, ok := c.Value.(int)
-	if !ok {
-		return 0, fmt.Errorf("failed to convert int for key %s", key)
-	}
-	return intData, nil
+	/*
+		intData, ok := c.Value.(int)
+		if !ok {
+			return 0, fmt.Errorf("failed to convert int for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // GetString retrive a string value from the context using StateManager
@@ -130,19 +131,20 @@ func (context *Context) GetString(key string) (string, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value string `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return "", fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	stringData, ok := c.Value.(string)
-	if !ok {
-		return "", fmt.Errorf("failed to convert string for key %s", key)
-	}
-	return stringData, nil
+	/*
+		stringData, ok := c.Value.(string)
+		if !ok {
+			return "", fmt.Errorf("failed to convert string for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // GetBytes retrive a byte array from the context using StateManager
@@ -153,19 +155,20 @@ func (context *Context) GetBytes(key string) ([]byte, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value []byte `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	byteData, ok := c.Value.([]byte)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert byte array for key %s", key)
-	}
-	return byteData, nil
+	/*
+		byteData, ok := c.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert byte array for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // GetBool retrive a boolean value from the context using StateManager
@@ -176,19 +179,20 @@ func (context *Context) GetBool(key string) (bool, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value bool   `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return false, fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	boolData, ok := c.Value.(bool)
-	if !ok {
-		return false, fmt.Errorf("failed to convert boolean for key %s", key)
-	}
-	return boolData, nil
+	/*
+		boolData, ok := c.Value.(bool)
+		if !ok {
+			return false, fmt.Errorf("failed to convert boolean for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // Del deletes a value from the context using StateManager

--- a/example/deploy.sh
+++ b/example/deploy.sh
@@ -1,3 +1,2 @@
 #!/bin/bash
-
 faas-cli deploy -f stack.yml

--- a/example/upload-pipeline-async.yml
+++ b/example/upload-pipeline-async.yml
@@ -3,3 +3,4 @@ environment:
   gateway: "gateway:8080"
   enable_tracing: false
   enable_hmac: false
+  intermidiate_storage: true

--- a/example/upload-pipeline/handler.go
+++ b/example/upload-pipeline/handler.go
@@ -47,7 +47,6 @@ func Define(flow *faasflow.Workflow, context *faasflow.Context) (err error) {
 				if err != nil {
 					return nil, fmt.Errorf("Failed to retrive picture from state, error %v", err)
 				}
-
 				return data, nil
 			}
 			return nil, fmt.Errorf("More than one face detected, picture should contain single face")

--- a/template/faasflow/statemanager.go
+++ b/template/faasflow/statemanager.go
@@ -23,6 +23,11 @@ func retriveStateManager(state map[string]string) *requestEmbedStateManager {
 	return rstate
 }
 
+// Init initialize the statemanager with requestId and flowname
+func (rstate *requestEmbedStateManager) Init(flowName string, requestId string) error {
+	return nil
+}
+
 // Set sets a value (implement StateManager)
 func (rstate *requestEmbedStateManager) Set(key string, value string) error {
 	rstate.state[key] = value

--- a/template/faasflow/vendor/github.com/s8sg/faasflow/context.go
+++ b/template/faasflow/vendor/github.com/s8sg/faasflow/context.go
@@ -18,6 +18,8 @@ type Context struct {
 
 // StateManager for State Manager
 type StateManager interface {
+	// Initialize the StateManager with flow name and request ID
+	Init(flowName string, requestId string) error
 	// Set store a value for key, in failure returns error
 	Set(key string, value string) error
 	// Get retrives a value by key, if failure returns error
@@ -46,9 +48,14 @@ func CreateContext(id string, phase int, name string) *Context {
 	return context
 }
 
-// SetStateManager sets the state manager
-func (context *Context) SetStateManager(state StateManager) {
+// SetStateManager sets and overwrite the state manager
+func (context *Context) SetStateManager(state StateManager) error {
 	context.stateManager = state
+	err := context.stateManager.Init(context.Name, context.requestId)
+	if err != nil {
+		return fmt.Errorf("Failed to initialize StateManager, error %v", err)
+	}
+	return nil
 }
 
 // GetRequestId returns the request id

--- a/template/faasflow/vendor/github.com/s8sg/faasflow/context.go
+++ b/template/faasflow/vendor/github.com/s8sg/faasflow/context.go
@@ -107,19 +107,20 @@ func (context *Context) GetInt(key string) (int, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value int    `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return 0, fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	intData, ok := c.Value.(int)
-	if !ok {
-		return 0, fmt.Errorf("failed to convert int for key %s", key)
-	}
-	return intData, nil
+	/*
+		intData, ok := c.Value.(int)
+		if !ok {
+			return 0, fmt.Errorf("failed to convert int for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // GetString retrive a string value from the context using StateManager
@@ -130,19 +131,20 @@ func (context *Context) GetString(key string) (string, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value string `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return "", fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	stringData, ok := c.Value.(string)
-	if !ok {
-		return "", fmt.Errorf("failed to convert string for key %s", key)
-	}
-	return stringData, nil
+	/*
+		stringData, ok := c.Value.(string)
+		if !ok {
+			return "", fmt.Errorf("failed to convert string for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // GetBytes retrive a byte array from the context using StateManager
@@ -153,19 +155,20 @@ func (context *Context) GetBytes(key string) ([]byte, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value []byte `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	byteData, ok := c.Value.([]byte)
-	if !ok {
-		return nil, fmt.Errorf("failed to convert byte array for key %s", key)
-	}
-	return byteData, nil
+	/*
+		byteData, ok := c.Value.(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to convert byte array for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // GetBool retrive a boolean value from the context using StateManager
@@ -176,19 +179,20 @@ func (context *Context) GetBool(key string) (bool, error) {
 	}
 
 	c := struct {
-		Key   string      `json:"key"`
-		Value interface{} `json:"value"`
+		Key   string `json:"key"`
+		Value bool   `json:"value"`
 	}{}
 	err = json.Unmarshal([]byte(data), &c)
 	if err != nil {
 		return false, fmt.Errorf("Failed to unmarshal data, error %v", err)
 	}
 
-	boolData, ok := c.Value.(bool)
-	if !ok {
-		return false, fmt.Errorf("failed to convert boolean for key %s", key)
-	}
-	return boolData, nil
+	/*
+		boolData, ok := c.Value.(bool)
+		if !ok {
+			return false, fmt.Errorf("failed to convert boolean for key %s", key)
+		}*/
+	return c.Value, nil
 }
 
 // Del deletes a value from the context using StateManager


### PR DESCRIPTION
Closes: #13 

Commits adds implementation of `intermediate_storage`.  
If set as `true`, the **StateManager** is used to store intermediate result;    
otherwise intermediate data gets forwarded with async call.   
   
   
Using `async` forward has disadvantage with `nats` as it support `< 1 mb` of data. For larger data it's recommended to use the `intermediate_storage` feature. 
    
`intermediate_storage` data are automatically cleaned 